### PR TITLE
workaround for pandoc 1.12

### DIFF
--- a/writer.lua
+++ b/writer.lua
@@ -79,6 +79,10 @@ function Doc(body, metadata, variables)
   local function add(s)
     table.insert(buffer, s)
   end
+  add("---")
+  add("layout: default")
+  add("---")
+  add("<div class=\"content\">")
   add(body)
   if panel_started then
     add("</div>")
@@ -93,6 +97,8 @@ function Doc(body, metadata, variables)
     end
     add('</ol>')
   end
+
+  add("</div>")
   return table.concat(buffer,'\n') .. '\n'
 end
 


### PR DESCRIPTION
This is a workaround for a feature missing in pandoc 1.12 (templates don't work with custom writers before version 1.13).

Disclaimer: This is 100% evil and I'm not responsible for that if anyone actually merges it in.