### PR TITLE
empty template

### DIFF
--- a/template.html
+++ b/template.html
@@ -1,6 +1,1 @@
----
-layout: default
----
-<div class="content">
 $body$
-</div>


### PR DESCRIPTION
Since template contents are now in writer script for backwards compatibility, I removed them from template.html, so now it should work on both old and new versions of pandoc.